### PR TITLE
Update to Nextcloud 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloud:16
+FROM nextcloud:17
 
 RUN apt-get update -y && apt-get install -y jq sudo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloud:15
+FROM nextcloud:16
 
 RUN apt-get update -y && apt-get install -y jq sudo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloud:17
+FROM nextcloud:16
 
 RUN apt-get update -y && apt-get install -y jq sudo
 


### PR DESCRIPTION
Updates Nextcloud to Version 17. Only possible if Nextcloud is already Version 16.

@gabriel-v 
Error in the Calender App: 
Your configured timezone ({timezoneId}) was not found. Falling back to UTC.
Please change your timezone in the settings and report this issue.