### PR TITLE
Revert "Update to Nextcloud 16"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloud:16
+FROM nextcloud:15
 
 RUN apt-get update -y && apt-get install -y jq sudo
 


### PR DESCRIPTION
Reverts liquidinvestigations/liquid-nextcloud#11 since we abandoned the prospect of using Nextcloud 16 or 17 since 18 is already here.